### PR TITLE
Add silent renew entry point

### DIFF
--- a/cfg/base.js
+++ b/cfg/base.js
@@ -15,7 +15,7 @@ module.exports = {
   devtool: 'eval',
   output: {
     path: path.join(__dirname, '/../dist/assets'),
-    filename: 'app.js',
+    filename: '[name].js',
     publicPath: defaultSettings.publicPath
   },
   postcss: () => {

--- a/cfg/dev.js
+++ b/cfg/dev.js
@@ -10,12 +10,17 @@ let BowerWebpackPlugin = require('bower-webpack-plugin');
 const DotenvPlugin = require('webpack-dotenv-plugin');
 
 let config = Object.assign({}, baseConfig, {
-  entry: [
-    'webpack-dev-server/client?http://127.0.0.1:' + defaultSettings.port,
-    'webpack/hot/only-dev-server',
-    'babel-polyfill',
-    './src/index'
-  ],
+  entry: {
+    'app': [
+      'webpack-dev-server/client?http://127.0.0.1:' + defaultSettings.port,
+      'webpack/hot/only-dev-server',
+      'babel-polyfill',
+      './src/index'
+    ],
+    'silent_renew': [
+      './src/silent_renew'
+    ]
+  },
   cache: true,
   devtool: 'eval-source-map',
   plugins: [

--- a/cfg/dist.js
+++ b/cfg/dist.js
@@ -11,7 +11,10 @@ let BowerWebpackPlugin = require('bower-webpack-plugin');
 const DotenvPlugin = require('webpack-dotenv-plugin');
 
 let config = Object.assign({}, baseConfig, {
-  entry: ['babel-polyfill', path.join(__dirname, '../src/index')],
+  entry: {
+    'app': ['babel-polyfill', path.join(__dirname, '../src/index')],
+    'silent_renew': [path.join(__dirname, '../src/silent_renew')]
+  },
   cache: false,
   devtool: 'sourcemap',
   plugins: [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "",
   "scripts": {
     "clean": "rimraf dist/*",
-    "copy": "copyfiles -f ./src/index.html ./src/favicon.ico ./dist",
+    "copy": "copyfiles -f ./src/index.html ./src/silent_renew.html ./src/favicon.ico ./dist",
     "dist": "npm run copy & webpack --env=dist",
     "lint": "eslint ./src",
     "posttest": "npm run lint",

--- a/src/silent_renew.html
+++ b/src/silent_renew.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Silent Renew</title>
+  </head>
+  <body>
+    <script type="text/javascript" src="/assets/silent_renew.js"></script>
+  </body>
+</html>

--- a/src/silent_renew.js
+++ b/src/silent_renew.js
@@ -1,0 +1,3 @@
+import {UserManager} from 'oidc-client';
+
+new UserManager().signinSilentCallback();


### PR DESCRIPTION
The OIDC Client must have additional redirect_uri configured for silent renew to work.

e.g. if in Tunnistamo the helpt-ui client redirect is now:
http://localhost:8001/callback

One should add a new redirect_uri like this:
http://localhost:8001/silent_renew.html